### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,8 @@ Contributions are welcome! Please open issues or pull requests. For larger chang
 ## 📄 License
 
 MIT
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/thomasmarches-substrate-mcp-rs).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/thomasmarches-substrate-mcp-rs).